### PR TITLE
Specifiy pwa orientation to prevent locking to portrait

### DIFF
--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -161,6 +161,7 @@ module.exports = (env, argv) => {
                 background_color: '#f5f5f5',
                 start_url: '/',
                 display: 'fullscreen',
+                orientation: 'any',
                 fingerprints: !devMode,
                 icons: [
                     {


### PR DESCRIPTION
While experimenting with the option to add the page to my home screen I noticed that the default orientation `webpack-pwa-manifest` is portrait if not specified, preventing the ability to to rotate to landscape for wide pages.

This PR simply specifies that any orientation can be used.