### PR TITLE
fixed type for query builder

### DIFF
--- a/web/src/js/model/query-builder.ts
+++ b/web/src/js/model/query-builder.ts
@@ -50,7 +50,7 @@ export class QueryBuilder<T extends Model> {
         const type: Type = this.TClass.types[field] || this.TClass.searchTypes[field]
         if (value instanceof RegExp) {
             value = value.source
-        } else if (typeof value === 'string' && type.type === 'Regex') {
+        } else if (typeof value === 'string' && type.type === 'String') {
             value = '^' + escapeRegExp(value) + '$'
         }
         const where: Where = {


### PR DESCRIPTION
The type.type value is for the value of the regular type, not the input type so it will never have the regex type. All strings use the regex type to search by