### PR TITLE
replaced animating top with translate3D

### DIFF
--- a/web/src/js/components/parallax.tsx
+++ b/web/src/js/components/parallax.tsx
@@ -35,7 +35,7 @@ export default class Parallax extends Component<JSX.HTMLAttributes> {
     private frame() {
         if (this.img) {
             const scrollTop = document.documentElement!.scrollTop
-            this.img.style.top = scrollTop / 2 + 'px'
+            this.img.style.transform = `translate3D(0, ${scrollTop / 2}px, 0)`
         }
         if (this.mounted) {
             window.requestAnimationFrame(this.frame)

--- a/web/src/js/components/top-bar.tsx
+++ b/web/src/js/components/top-bar.tsx
@@ -67,8 +67,7 @@ export default class TopBar extends Component<Props & JSX.HTMLAttributes> {
         if (this.lastScrollTop !== scrollTop && this.header) {
             this.offset = clamp(this.offset + this.lastScrollTop - scrollTop, -headerHeight, 0)
 
-            this.header.style.top = this.offset + 'px'
-
+            this.header.style.transform = `translate3D(0, ${this.offset}px, 0)`
             if (scrollTop + this.offset === 0 && this.props.clear) {
                 this.header.classList.add(s.hidden)
             } else {


### PR DESCRIPTION
Using transform instead of top cuts out a couple of steps when rendering and should make the parallax and top bar more smooth

Closes #60 